### PR TITLE
Bad indentation fix

### DIFF
--- a/scripts/modules/rainbow.lua
+++ b/scripts/modules/rainbow.lua
@@ -32,7 +32,7 @@ function Rainbow:update(dt)
 			local g = (math.sin(f + t + 2) + 1) * 255 / 2
 			local b = (math.sin(f + t + 4) + 1) * 255 / 2
 
-			self.bgleds[x][y].r = r
+	    self.bgleds[x][y].r = r
             self.bgleds[x][y].g = g
             self.bgleds[x][y].b = b
 		end


### PR DESCRIPTION
Line 35 in scripts/modules/rainbow.lua

The end result is the same, but looping over red variable's assignment is using a bit more overhead than needed.
